### PR TITLE
Tap service has been enabled for synchronous queries.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,6 @@ ENV PYTHONDONTWRITEBYTECODE=1
 # This option has no effect on the stdin stream.
 ENV PYTHONUNBUFFERED=1
 
-
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends \ 
     build-essential \
@@ -24,26 +23,18 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     ldap-utils \
     git
 
-
 # Install python packages
 COPY ./requirements.txt /tmp/pip-tmp/
 RUN pip install --upgrade pip setuptools wheel  && \
     pip --disable-pip-version-check --no-cache-dir install -r /tmp/pip-tmp/requirements.txt \
     && rm -rf /tmp/pip-tmp
 
-# FROM python:3.9-slim-bullseye
-
-# COPY --from=builder /usr/lib/x86_64-linux-gnu /usr/lib/x86_64-linux-gnu
-# COPY --from=builder /opt/venv /opt/venv
-# ENV PATH="/opt/venv/bin:$PATH"
+ENV PATH="/home/daiquiri/.local/bin:$PATH"
 
 # Create the non-root user up front
 ARG USERNAME=daiquiri
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
-
-# RUN groupadd --gid $USER_GID $USERNAME \
-#     && useradd -s /bin/bash --uid $USER_UID --gid $USER_GID -m $USERNAME
 
 RUN groupadd --gid ${USER_GID} $USERNAME \
     && useradd --uid ${USER_UID} --gid ${USER_GID} -m ${USERNAME} \

--- a/consume_tap.ipynb
+++ b/consume_tap.ipynb
@@ -1,0 +1,161 @@
+{
+ "cells": [
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Exemplo consumindo dados do Tap Service local usando pyvo."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "pyvo version 1.4.1 \n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "from pkg_resources import parse_version\n",
+    "import pyvo\n",
+    "\n",
+    "#\n",
+    "# Verify the version of pyvo\n",
+    "#\n",
+    "if parse_version(pyvo.__version__) < parse_version('1.0'):\n",
+    "    raise ImportError('pyvo version must be at least than 1.0')\n",
+    "\n",
+    "print('\\npyvo version %s \\n' % (pyvo.__version__,))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "TAP service LIneA Tap Service \n",
+      "\n",
+      "Is Available: [True]\n"
+     ]
+    }
+   ],
+   "source": [
+    "import requests\n",
+    "import pyvo\n",
+    "\n",
+    "#\n",
+    "# Setup tap_service connection\n",
+    "#\n",
+    "service_name = \"LIneA Tap Service\"\n",
+    "\n",
+    "# url = \"http://localhost/daiquiri/tap\"\n",
+    "url = \"http://172.24.0.1/daiquiri/tap\"\n",
+    "# token = 'Token <your-token>'\n",
+    "\n",
+    "print('TAP service %s \\n' % (service_name,))\n",
+    "\n",
+    "# Setup authorization\n",
+    "tap_session = requests.Session()\n",
+    "# tap_session.headers['Authorization'] = token\n",
+    "\n",
+    "tap_service = pyvo.dal.TAPService(url, session=tap_session)\n",
+    "\n",
+    "print(f\"Is Available: [{tap_service.available}]\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     source_id             ra               dec       \n",
+      "------------------- ---------------- -----------------\n",
+      "2481164162647472896 25.6125071432181 -3.40107774130801\n",
+      "2481164162647215872 25.6124278693609 -3.39986096035102\n",
+      "2481164815482501760 25.6405138604541 -3.39845373990014\n",
+      "                ...              ...               ...\n",
+      "2505540880900538624 26.0438362958819 -2.05610056901392\n",
+      "2505540885191179520 26.0458589688854 -2.05363809357809\n",
+      "2505529507822383616 26.0715228258224   -2.054553573444\n",
+      "Length = 5152 rows\n"
+     ]
+    }
+   ],
+   "source": [
+    "query = \"SELECT source_id, ra, dec from gaia.gaia_dr2\"\n",
+    "\n",
+    "tap_result = tap_service.run_sync(query, language=\"adql\")\n",
+    "\n",
+    "tap_result.to_table().pprint(max_lines=10)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     source_id             ra               dec       \n",
+      "------------------- ---------------- -----------------\n",
+      "2481164162647472896 25.6125071432181 -3.40107774130801\n",
+      "2481164162647215872 25.6124278693609 -3.39986096035102\n",
+      "2481164815482501760 25.6405138604541 -3.39845373990014\n",
+      "                ...              ...               ...\n",
+      "2481354373864185472  25.652681600925 -3.28504188336291\n",
+      "2481377841565481600  25.660691285969 -3.27795935544838\n",
+      "2481164952921455104 25.6647616331409  -3.3790326249827\n",
+      "Length = 20 rows\n"
+     ]
+    }
+   ],
+   "source": [
+    "query = \"SELECT source_id, ra, dec from gaia.gaia_dr2 limit 20\"\n",
+    "\n",
+    "tap_result = tap_service.run_sync(query, language=\"postgresql\")\n",
+    "\n",
+    "tap_result.to_table().pprint(max_lines=10)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.16"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
     restart: always
     # restart: unless-stopped
     volumes:
-      - ./init-db.sh:/docker-entrypoint-initdb.d/init-db.sh
+      # - ./init-db.sh:/docker-entrypoint-initdb.d/init-db.sh
       - postgres-data:/var/lib/postgresql/data
       - ./database_sample:/data
     environment:

--- a/local_sample.py
+++ b/local_sample.py
@@ -2,7 +2,7 @@
 BASE_HOST = "http://localhost/daiquiri"
 
 # A list of strings representing the host/domain names that this Django site can serve.
-ALLOWED_HOSTS = ["localhost", "127.0.0.1", "::1"]
+ALLOWED_HOSTS = ["localhost", "127.0.0.1", "::1", "*"]
 
 # Public URL of the Daiquiri site. Used for VO and OAI metadata.
 # Default: http://localhost:8000
@@ -140,3 +140,9 @@ QUERY_LANGUAGES = [
         "quote_char": '"',
     },
 ]
+
+# daiquiri.query.settings
+# Designates if the query interface can be accessed by anonymus users.
+# The permissions on schemas and tables need to be configured using the metadata interface.
+# Default: False
+QUERY_ANONYMOUS = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -83,3 +83,5 @@ wcwidth==0.2.6
 XlsxWriter==3.0.7
 zipp==3.11.0
 uWSGI==2.0.21
+pyvo==1.4.1
+astroquery==0.4.6


### PR DESCRIPTION
O Ambiente de desenvolvimento está configurado para executar querys via TAP. 

Para testar, 
- Instalar o ambiente com as configurações default. 
- antes de iniciar o database pela primeira vez descomentar a linha `- ./init-db.sh:/docker-entrypoint-initdb.d/init-db.sh`
- registrar a tabela de testes do gaia. 
- Alterar a permissão dela para publica.
- Verificar se a interface query está funcionando normalmente. 

Com o ambiente funcionando 
- baixe o TOPCAT
- Menu VO -> Table Access Protocol 
- No final da janela no campo TAP URL digitar http://localhost/daiquiri/tap
- Verificar se os schemas e tabelas foram listados
- executar uma query simples de teste.