### PR TITLE
user info from comanage

### DIFF
--- a/daiquiri/config/settings/base.py
+++ b/daiquiri/config/settings/base.py
@@ -145,4 +145,10 @@ if AUTH_SHIB_ENABLED == True:
     # Including Shibboleth authentication:
     AUTHENTICATION_BACKENDS += ("shibboleth.backends.ShibbolethRemoteUserBackend",)
 
+# COmanage Autorization
+COMANAGE_SERVER_URL = "https://register.linea.org.br"
+COMANAGE_USER = ""
+COMANAGE_PASSWORD = ""
+COMANAGE_COID = 2
+
 SETTINGS_EXPORT += ["AUTH_SHIB_ENABLED", "LOGIN_URL", "LOGOUT_URL"]

--- a/daiquiri/linea/comanage.py
+++ b/daiquiri/linea/comanage.py
@@ -1,0 +1,126 @@
+import requests
+import urllib.parse
+
+
+class Comanage:
+
+    def __init__(self, service_url: str, user: str, password: str, coid: int = 2):
+
+        self.service_url = service_url
+        self.user = user
+        self.password = password
+        self.coid = coid
+
+    def request(self, endpoint: str, params: dict):
+
+        try:
+            url = urllib.parse.urljoin(self.service_url, endpoint)
+
+            r = requests.get(url, auth=(self.user, self.password), params=params)
+
+            if r.status_code == 200:
+                return r.json()
+            else:
+                raise Exception(f"Request Fail with status code: {r.status_code}")
+
+            # TODO: Tratar os demais códigos de retorno
+
+        except Exception as e:
+            raise Exception(e)
+
+    def get_org_identities(self, identifier: str):
+        """Recupera a OI da pessoa pelo eppn (identificador)
+
+        Exemplo: GET https://register.linea.org.br/registry/org_identities.json?coid=2&search.identifier=6f9a1fe31eb504c3823b8277f9894f14@ifsc.edu.br
+        """
+        # Em caso de erro 204 - Significa que não tem nenhum link associado ao eppn
+        return self.request(
+            "registry/org_identities.json",
+            {"coid": self.coid, "search.identifier": identifier},
+        )
+
+    def get_org_identity_id(self, identifier: str):
+        result = self.get_org_identities(identifier=identifier)
+
+        org_identities = result["OrgIdentities"]
+        if len(org_identities) != 1:
+            raise Exception(
+                f"get_org_identities deveria retornar apenas um resultado mas retornou {len(org_identities)}"
+            )
+
+        return org_identities[0]["Id"]
+
+    def get_org_identities_links(self, identifier: str):
+        """Recupera links de CO Person de acordo com a chave `id` da consulta org_identities
+
+        Exemplo: GET https://register.linea.org.br/registry/co_org_identity_links.json?orgidentityid=692
+        """
+
+        # orgidentityid
+        oi = self.get_org_identity_id(identifier)
+        return self.request(
+            "registry/co_org_identity_links.json", {"orgidentityid": oi}
+        )
+
+    def get_co_person_id(self, identifier: str):
+
+        result = self.get_org_identities_links(identifier)
+
+        identity_links = result["CoOrgIdentityLinks"]
+        if len(identity_links) != 1:
+            raise Exception(
+                f"get_org_identities_links deveria retornar apenas um resultado mas retornou {len(identity_links)}"
+            )
+
+        return identity_links[0]["CoPersonId"]
+
+    def get_identifiers(self, copersonid: int):
+        """Recuperar identificadores internos de acordo com `copersonid`
+        Exemplo: GET https://register.linea.org.br/registry/identifiers.json?copersonid=412
+        """
+
+        result = self.request("registry/identifiers.json", {"copersonid": copersonid})
+        return result["Identifiers"]
+
+    def get_names(self, copersonid: int):
+        """Recuperar nomes de acordo com `copersonid`
+        Exemplo: GET https://register.linea.org.br/registry/names.json?copersonid=412
+        """
+        result = self.request("registry/names.json", {"copersonid": copersonid})
+        return result["Names"]
+
+    def get_emails(self, copersonid: int):
+        """Recuperar email de acordo com `copersonid`
+        Exemplo: GET https://register.linea.org.br/registry/email_addresses.json?copersonid=412
+        """
+        result = self.request(
+            "registry/email_addresses.json", {"copersonid": copersonid}
+        )
+        return result["EmailAddresses"]
+
+    def get_groups(self, copersonid: int, include_internal_groups: bool = False):
+        """Recuperar Grupos da Pessoa de acordo com `copersonid`
+        Exemplo: GET https://register.linea.org.br/registry/co_groups.json?copersonid=412
+        """
+        result = self.request("registry/co_groups.json", {"copersonid": copersonid})
+
+        if include_internal_groups:
+            return result["CoGroups"]
+        else:
+            groups = []
+            for group in result["CoGroups"]:
+                if group["Auto"] == False and group["GroupType"] == "S":
+                    groups.append(group)
+            return groups
+
+    def get_ldap_uid(self, identifier: str):
+
+        copersonid = self.get_co_person_id(identifier=identifier)
+
+        identifiers = self.get_identifiers(copersonid=copersonid)
+
+        for identifie in identifiers:
+            if identifie["Type"] == "uid":
+                return identifie["Identifier"]
+
+        raise Exception("Não encontrou usuario correspondente no ldap.")

--- a/daiquiri/linea/ldap.py
+++ b/daiquiri/linea/ldap.py
@@ -1,0 +1,32 @@
+import ldap
+
+
+def get_ldap_username_by_email(email):
+    # https://stackoverflow.com/a/29633047/24123418
+
+    AUTH_LDAP_SERVER_URI = "ldap://srvlslave01.linea.org.br:389"
+
+    conn = ldap.initialize(AUTH_LDAP_SERVER_URI)
+
+    criteria = f"(&(mail={email}))"
+
+    users = []
+    try:
+        res = conn.search_s("ou=people,dc=linea,dc=org", ldap.SCOPE_SUBTREE, criteria)
+
+        for dn, entry in res:
+            users.append(entry["uid"][0].decode())
+
+    except Exception as error:
+        print(error)
+
+    if len(users) == 1:
+        return users[0]
+    else:
+        raise Exception(
+            f"It was not possible to identify the user related to the email. {len(users)} results were found."
+        )
+
+
+# username = get_ldap_username_by_email("xxx@gmail.com")
+# print(username)

--- a/daiquiri/linea/shibboleth.py
+++ b/daiquiri/linea/shibboleth.py
@@ -1,12 +1,16 @@
 import logging
 
-from django.conf import settings
 from django.contrib.auth.models import Group
 
 from shibboleth.middleware import ShibbolethRemoteUserMiddleware
 
+# from linea.ldap import get_ldap_username_by_email
+from linea.comanage import Comanage
+from django.conf import settings
+
 
 class ShibbolethMiddleware(ShibbolethRemoteUserMiddleware):
+
     def make_profile(self, user, shib_meta):
         """
         This is here as a stub to allow subclassing of ShibbolethRemoteUserMiddleware
@@ -14,31 +18,92 @@ class ShibbolethMiddleware(ShibbolethRemoteUserMiddleware):
         from the Shib provided attributes.  By default it does nothing.
         """
         log = logging.getLogger("shibboleth")
-        log.debug(settings.MIDDLEWARE)
-        log.debug(settings.AUTHENTICATION_BACKENDS)
-        log.debug(settings.SHIBBOLETH_ATTRIBUTE_MAP)
+        log.debug("Starting authentication with Shibboleth")
 
-        # Usar essa url depois de logado para ver os atributos disponiveis
-        # https://userquery-dev.linea.org.br/Shibboleth.sso/Session
-
-        log.info("Shibboleth::make_profile()")
         log.debug(f"Shib Meta: {shib_meta}")
-        log.debug(f"User: {user}")
 
-        # Guardar o email do usuario
+        # eppn identity from shib meta atributes
+        eppn = shib_meta["username"]
+
+        # Sempre atualiza o email do usuario do usuario
         user.email = shib_meta["email"]
-        log.info("Updated user email")
-
         user.save()
 
         try:
-            # Adicionar o usuario ao grupo Shibboleth
-            group, created = Group.objects.get_or_create(name="Shibboleth")
-            user.groups.add(group)
-            log.info("Added user to Shibboleth group")
-        except Exception as e:
-            log.error("Failed on add user to group shibboleth. Error: %s" % e)
+            # Instantiate Commange
+            co = Comanage(
+                service_url=settings.COMANAGE_SERVER_URL,
+                user=settings.COMANAGE_USER,
+                password=settings.COMANAGE_PASSWORD,
+                coid=settings.COMANAGE_COID,
+            )
 
-        log.debug("--------------------------")
+            log.debug("Retriving ldap uid from comanage.")
+            ldap_uid = co.get_ldap_uid(identifier=eppn)
+            log.debug(f"LDAP UID: {ldap_uid}")
+
+            log.debug("Updating user.profile.display_name.")
+            user.profile.display_name = ldap_uid
+            user.profile.save()
+            log.debug(f"Changed display name to {user.profile.display_name}")
+
+        except Exception as e:
+            msg = f"Failed on retrive ldap uid from COmanager. Error: {e}"
+            log.error(msg)
+            raise Exception(msg)
+
+        self.setup_groups(user, shib_meta)
+
+        log.debug("".rjust(40, "-"))
 
         return
+
+    def setup_groups(self, user, shib_meta):
+        log = logging.getLogger("shibboleth")
+
+        log.debug("Setup User Groups")
+
+        # eppn identity from shib meta atributes
+        eppn = shib_meta["username"]
+
+        # Add a custom group shibboleth for mark this user make login using shibboleth.
+        groups = ["Shibboleth"]
+
+        # Recupera os grupos do usuario
+        # TODO: deveria usar o metodo: update_user_groups
+        # https://github.com/Brown-University-Library/django-shibboleth-remoteuser/blob/main/shibboleth/middleware.py#L86
+        try:
+
+            # Instantiate Commange
+            co = Comanage(
+                service_url=settings.COMANAGE_SERVER_URL,
+                user=settings.COMANAGE_USER,
+                password=settings.COMANAGE_PASSWORD,
+                coid=settings.COMANAGE_COID,
+            )
+
+            log.error("Retriving User Groups from COmanage.")
+            personid = co.get_co_person_id(eppn)
+            cogroups = co.get_groups(personid)
+
+            for group in cogroups:
+                groups.append(group["Name"])
+
+        except Exception as e:
+            msg = f"Failed on retrive groups from COmanage. Error: {e}"
+            log.error(msg)
+            raise Exception(msg)
+
+        # Remove the user from all groups that are not specified in the shibboleth metadata
+        for group in user.groups.all():
+            if group.name not in groups:
+                group.user_set.remove(user)
+                log.debug(f"User has been removed from the group {group.name}")
+
+        # Add the user to all groups in the shibboleth metadata
+        for g in groups:
+            group, created = Group.objects.get_or_create(name=g)
+            group.user_set.add(user)
+
+        log.debug("User has been added to the following groups")
+        log.debug(f"Groups: {groups}")

--- a/daiquiri/templates/core/base_navigation.html
+++ b/daiquiri/templates/core/base_navigation.html
@@ -87,7 +87,7 @@
 
                 <li class="dropdown">
                     <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
-                        {{ user.profile.full_name }}<span class="caret"></span>
+                        {{ user.first_name }}<span class="caret"></span>
                     </a>
                     <ul class="dropdown-menu">
                         <li>


### PR DESCRIPTION
Foi adicionada uma classe que permite recuperar as informações do usuario após o login federado. 

Não foi possivel criar um display_name para o usuario como fazemos nas outras aplicações. foi necessário substituir o campo first_name pelo UID interno do linea. e depois alterar o template para exibir apenas o first_name. 
