### PR TITLE
added repo idac_dw as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "idac_dw"]
+	path = idac_dw
+	url = https://github.com/linea-it/idac_dw


### PR DESCRIPTION
Adicionei o repositório idac_dw como um submodulo, assim mantemos separada a documentação dos catálogos do repositório principal do userquery. 
Essa separação é importante, pois essa mesma documentação deve ser disponibilizada na infraestrutura interna de armazenamento onde ficarão os arquivos dos catálogos.